### PR TITLE
switch to gtk-renderer as default

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,8 @@
-julia 0.2
+julia 0.3
 Cairo
+Gtk
 Colors
 IniFile
-Tk
 Compat 0.4.4
 Graphics 0.1
 Dates

--- a/src/Winston.ini
+++ b/src/Winston.ini
@@ -1,4 +1,4 @@
-output_surface          = tk
+output_surface          = gtk
 fontsize_min            = 1.25
 
 ;[device]

--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -9,7 +9,12 @@ else
 end
 using IniFile
 using Compat
-using Dates
+if VERSION < v"0.4.0-"
+    using Dates
+else
+    using Base.Dates
+end
+import Base: *
 
 isdefined(Base, :Libc) && (strftime = Libc.strftime)
 isdefined(Base, :Dates) && (datetime2unix = Dates.datetime2unix)
@@ -75,7 +80,7 @@ export
     setattr,
     style,
     svg,
-    
+
     getcomponents,
     rmcomponents,
     grid,
@@ -1302,7 +1307,7 @@ function rmcomponents(p::FramedPlot, t::Type, args...)
     todel = find(map(x -> (x <: t), ctypes))
     rmcomponents(p, todel, args...)
 end
-    
+
 # Table ------------------------------------------------------------------------
 
 type _Grid
@@ -2472,7 +2477,7 @@ end
 # FramedComponent ---------------------------------------------------------------
 
 abstract FramedComponent <: PlotComponent
-    
+
 function make_key(self::FramedComponent, bbox::BoundingBox)
     p = lowerleft(bbox)
     q = upperright(bbox)
@@ -2504,7 +2509,7 @@ _kw_rename(::FramedBar) = @Dict(
 )
 
 function limits(self::FramedBar, window::BoundingBox)
-    x = [1, length(self.g)] + 
+    x = [1, length(self.g)] +
         getattr(self, "barwidth") * [-.5, .5] +
         getattr(self, "offset")
     y = [extrema(self.h)...]

--- a/src/gtk.jl
+++ b/src/gtk.jl
@@ -6,7 +6,7 @@ function gtkwindow(name, w, h, closecb=nothing)
     if closecb !== nothing
         Gtk.on_signal_destroy(closecb, win)
     end
-    show(c)
+    showall(c)
 end
 
 function display(c::Gtk.Canvas, pc::PlotContainer)
@@ -30,13 +30,15 @@ end
 
 gtkdestroy(c::Gtk.Canvas) = Gtk.destroy(Gtk.toplevel(c))
 
-# JWN: copied the following from tk.jl, but I don't know
-# what it does, so I can't make sure it works
-#
-#function get_context(c::Gtk.Canvas, pc::PlotContainer)
-#    device = CairoRenderer(Gtk.cairo_surface(c))
-#    ext_bbox = BoundingBox(0,width(c),0,height(c))
-#    _get_context(device, ext_bbox, pc)
-#end
-#
-#get_context(pc::PlotContainer) = get_context(curfig(_display), pc)
+function gtkdestroy(c::Gtk.Canvas)
+    Gtk.destroy(Gtk.toplevel(c))
+    nothing
+end
+
+function get_context(c::Gtk.Canvas, pc::PlotContainer)
+    device = CairoRenderer(Gtk.cairo_surface(c))
+    ext_bbox = BoundingBox(0,width(c),0,height(c))
+    _get_context(device, ext_bbox, pc)
+end
+
+get_context(pc::PlotContainer) = get_context(curfig(_display).window, pc)


### PR DESCRIPTION
This is a rebase of #173. Now that Gtk can be precompiled, there is no disadvantage to making it the default.

I have not yet succeeded in turning on precompilation for Winston; since Tk is not precompilable, I think the easiest way to achieve that would be to just ditch Tk altogether. It would be interesting to hear your thoughts before I embark on such a mission.
