### PR TITLE
fix deprecation warn

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ Compat 0.18.0
 Graphics 0.2.0
 StatsBase 0.13.1
 NaNMath 0.2.4
+Gtk 0.11.0

--- a/src/gtk.jl
+++ b/src/gtk.jl
@@ -1,7 +1,7 @@
 import Gtk
 
 function gtkwindow(name, w, h, closecb=nothing)
-    c = Gtk.@Canvas()
+    c = Gtk.GtkCanvas()
     win = Gtk.GtkWindow(c, name, w, h)
     if closecb !== nothing
         Gtk.on_signal_destroy(closecb, win)

--- a/src/gtk.jl
+++ b/src/gtk.jl
@@ -2,7 +2,7 @@ import Gtk
 
 function gtkwindow(name, w, h, closecb=nothing)
     c = Gtk.@Canvas()
-    win = Gtk.@Window(c, name, w, h)
+    win = Gtk.GtkWindow(c, name, w, h)
     if closecb !== nothing
         Gtk.on_signal_destroy(closecb, win)
     end

--- a/test/canvasgtkcompat.jl
+++ b/test/canvasgtkcompat.jl
@@ -1,4 +1,4 @@
 # minimalistic compatibility definitions
 const Toplevel = Gtk.WindowLeaf
 pack(x...;y...) = nothing
-Canvas(w, x, y) = ((w |> (c=show(Gtk.@Canvas(x,y)))); c)
+Canvas(w, x, y) = ((w |> (c=show(Gtk.GtkCanvas(x,y)))); c)


### PR DESCRIPTION
@Gtk.GtkWindow is deprecated, use Gtk.GtkWindow instead.