### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/gtk.jl
+++ b/src/gtk.jl
@@ -1,8 +1,8 @@
 import Gtk
 
 function gtkwindow(name, w, h, closecb=nothing)
-    c = Gtk.@Canvas()
-    win = Gtk.@Window(c, name, w, h)
+    c = Gtk.Canvas()
+    win = Gtk.Window(c, name, w, h)
     if closecb !== nothing
         Gtk.on_signal_destroy(closecb, win)
     end


### PR DESCRIPTION
The macros for creating types in Gtk have been deprecated.