### PR TITLE
Fix gtk backend and make it default

### DIFF
--- a/src/Winston.ini
+++ b/src/Winston.ini
@@ -1,4 +1,4 @@
-output_surface          = tk
+output_surface          = gtk
 fontsize_min            = 1.25
 
 ;[device]

--- a/src/gtk.jl
+++ b/src/gtk.jl
@@ -20,10 +20,7 @@ function display(c::Gtk.Canvas, pc::PlotContainer)
         try
             Winston.page_compose(pc, Gtk.cairo_surface(c))
         catch e
-            if isa(e, WinstonException)
-              println("Hallo")
-              rethrow(e)
-            end
+            isa(e, WinstonException) || rethrow(e)
             println("Winston: ", e.msg)
         end
     end

--- a/src/gtk.jl
+++ b/src/gtk.jl
@@ -20,7 +20,6 @@ function display(c::Gtk.Canvas, pc::PlotContainer)
         try
             Winston.page_compose(pc, Gtk.cairo_surface(c))
         catch e
-            bad = true
             if isa(e, WinstonException)
               println("Hallo")
               rethrow(e)
@@ -29,25 +28,6 @@ function display(c::Gtk.Canvas, pc::PlotContainer)
         end
     end
 end
-
-#=
-c.draw = let bad=false
-        function (_)
-            bad && return
-            ctx = getgc(c)
-            set_source_rgb(ctx, 1, 1, 1)
-            paint(ctx)
-            try
-                Winston.page_compose(pc, Gtk.cairo_surface(c))
-            catch e
-                bad = true
-                isa(e, WinstonException) || rethrow(e)
-                println("Winston: ", e.msg)
-            end
-        end
-    end
-    Gtk.draw(c)
-end =#
 
 gtkdestroy(c::Gtk.Canvas) = Gtk.destroy(Gtk.toplevel(c))
 


### PR DESCRIPTION
@ararslan:

In order to make it default I actually had to track down an issue which actually means that the gtk backend was never working on Julia 0.6.

If I get your approval I would do then the next step and remove the tk code. The current switch between Gtk and Winston is really not compatible with precompilation.