### PR TITLE
Fix timeplot vectorized funcs, add test

### DIFF
--- a/doc/fun/timeplot.rst
+++ b/doc/fun/timeplot.rst
@@ -17,7 +17,7 @@ Example
 
 .. winston::
 
-    using Base.Dates
+    using Dates
 
     t0 = DateTime(Year(2000), Month(3), Day(14), Hour(21), Minute(45))
     t1 = DateTime(Year(2000), Month(3), Day(14), Hour(22), Minute(22))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -658,13 +658,13 @@ end
 legend(lab::AbstractVector, args...; kvs...) = legend(_pwinston, lab, args...; kvs...)
 
 function timeplot(p::FramedPlot, x::Vector{DateTime}, y::AbstractArray, args...; kvs...)
-    limits = datetime2unix([minimum(x), maximum(x)])
+    limits = datetime2unix.([minimum(x), maximum(x)])
 
     ticks = collect(0.0:0.2:1.0)
-    ticklabels = x[round(Int64, ticks * (length(x) - 1) + 1)]
-    normalized_x = (datetime2unix(x) - limits[1]) / (limits[2] - limits[1])
+    ticklabels = x[round.(Int64, ticks .* (length(x) - 1) .+ 1)]
+    normalized_x = (datetime2unix.(x) .- limits[1]) ./ (limits[2] - limits[1])
 
-    span = Int(x[end] - x[1]) / 1000
+    span = Dates.value(x[end] - x[1]) / 1000
     kvs = Dict(kvs)
 
     if :format in keys(kvs)

--- a/test/compare.jl
+++ b/test/compare.jl
@@ -1,6 +1,6 @@
 module ImageComparisons
     using Winston, Compat, Colors
-    using Printf, Random
+    using Dates, Printf, Random
     include("examples.jl")
     include("issues.jl")
     include("plot.jl")

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -6,7 +6,8 @@ export
     example04,
     #example05,
     example06,
-    example07
+    example07,
+    example08
 
 function example01()
     x = range(0, stop=3pi, length=100)
@@ -154,4 +155,14 @@ function example07()
     t[1,2] = p
 
     t
+end
+
+function example08()
+    t0 = DateTime(Year(2000), Month(3), Day(14), Hour(21), Minute(45))
+    t1 = DateTime(Year(2000), Month(3), Day(14), Hour(22), Minute(22))
+
+    x = collect(t0:Second(1):t1)
+    y = randn(length(x))
+
+    timeplot(x, y, format="%x\n%X")
 end


### PR DESCRIPTION
 * Fix error when calling `timeplot`:
```
ERROR: MethodError: no method matching datetime2unix(::Vector{DateTime})
Closest candidates are:
  datetime2unix(::DateTime) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Dates/src/conversions.jl:58
```
 * Update vectorized calls to new Julia vectorized syntax.
 * Update Dates usage.
 * Add test for timeplot.
![Screen Shot 2021-03-21 at 5 57 53 PM](https://user-images.githubusercontent.com/1876264/111913589-24e62e80-8a6f-11eb-989d-389466afe66b.png)
